### PR TITLE
New attribute: typeahead-focus-not-empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ var myApp = angular.module('myApp', ['typeahead-focus']);
 <!-- Use the 'input' element as follows -->
 <input type="text" ng-model="selected" typeahead="item for item in items | filter:$viewValue:$emptyOrMatch | limitTo:8" typeahead-focus class="form-control" >
 ```
+
+## Trigger only if typeahead has value
+
+There are number of cases when showing autocomplete for empty value does not make sense. 
+However, when user enters a value in typeahead, leaves the field and then enters it again - 
+typeahead should show the suggestions again.
+
+If you want the `typeahead-focus` to trigger only when there is some entered value, add the `typeahead-focus-not-empty` attribute, i.e.:
+
+```
+<input type="text" ng-model="selected" typeahead="item for item in items" typeahead-focus typeahead-focus-not-empty class="form-control" >
+```

--- a/typeahead-focus.js
+++ b/typeahead-focus.js
@@ -23,8 +23,18 @@ angular.module('typeahead-focus', [])
              * a menu option in the typeahead, this may cause unexpected behavior if we were to execute the rest
              * of this function
              */
-            if( ARROW_KEYS.indexOf(e.keyCode) >= 0 )
+            if (ARROW_KEYS.indexOf(e.keyCode) >= 0) {
               return;
+            }
+
+            /* This ensures that the typeahead will not show suggestions if the field is empty and the
+             * typeahead-focus-not-empty is set. This is helpful when suggesting from empty value does not really make
+             * sense (for example we are selecting from thousands of items from database). However, if user enters
+             * something, leaves and enter the field again - typeahead should show previous suggestions.
+             */
+            if (angular.isDefined(attr.typeaheadFocusNotEmpty) && !ngModel.$viewValue) {
+              return;
+            }
 
             var viewValue = ngModel.$viewValue;
 


### PR DESCRIPTION
This PR adds a new attribute `typeahead-focus-not-empty`.

There are number of cases when showing autocomplete for empty value does not make sense for example we are selecting from thousands of items from database and displaying a list with no filtering at all is pointless). However, when user enters a value in typeahead, leaves the field and then enters it again - typeahead should show the suggestions again.

If you want the `typeahead-focus` to trigger only when there is some entered value, add `the typeahead-focus-not-empty` attribute.