### PR TITLE
Added support for selecting elements using the enter-key

### DIFF
--- a/typeahead-focus.js
+++ b/typeahead-focus.js
@@ -24,7 +24,7 @@ angular.module('typeahead-focus', [])
              * a menu option in the typeahead, this may cause unexpected behavior if we were to execute the rest
              * of this function
              */
-            if( ARROW_KEYS.indexOf(e.keyCode) >= 0 || e.keyCode == ENTER_KEY)
+            if( ARROW_KEYS.indexOf(e.keyCode) >= 0 || e.keyCode === ENTER_KEY)
               return;
 
             var viewValue = ngModel.$viewValue;

--- a/typeahead-focus.js
+++ b/typeahead-focus.js
@@ -17,13 +17,14 @@ angular.module('typeahead-focus', [])
 
           // Array of keyCode values for arrow keys
           const ARROW_KEYS = [37,38,39,40];
+          const ENTER_KEY = 13;
 
           function manipulateViewValue(e) {
             /* we have to check to see if the arrow keys were in the input because if they were trying to select
              * a menu option in the typeahead, this may cause unexpected behavior if we were to execute the rest
              * of this function
              */
-            if( ARROW_KEYS.indexOf(e.keyCode) >= 0 )
+            if( ARROW_KEYS.indexOf(e.keyCode) >= 0 || e.keyCode == ENTER_KEY)
               return;
 
             var viewValue = ngModel.$viewValue;


### PR DESCRIPTION
added the enter key to the formula in order to select elements in the dropdown not only using the mouse pointer, but the Enter key as well. This will close the dropdown when the enter-key is pressed, (and does not interfere with validation).